### PR TITLE
Updated docs to reflect exposed function signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Exposes:
  - `history_is_stifled() -> bool`
  - `stifle_history(n: i32)`
  - `unstifle_history() -> i32`
- - `readline(prompt: &str) -> Option<~str>`
+ - `readline(prompt: &str) -> Option<String>`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,13 @@
 //! A Simple wrapper for libreadline or libedit
 //!
-//! Exports two functions:
+//! Exports seven functions:
 //!
 //!   - `add_history`
+//!   - `history`
+//!   - `history_expand`
+//!   - `history_is_stifled`
+//!   - `stifle_history`
+//!   - `unstifle_history`
 //!   - `readline`
 //!
 


### PR DESCRIPTION
Great work! I noticed the README still mentioned an obsolete pointer type in a function signature.